### PR TITLE
Fix: Invalid manifest.json

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
   "permissions": ["storage", "alarms", "notifications", "offscreen"],
   "action": {
     "default_popup": "popup.html"
-  },,
+  },
   "background": {
     "service_worker": "background.js"
   }


### PR DESCRIPTION
This PR fixes a critical bug that prevented the extension from loading due to an invalid 'manifest.json' file. The JSON syntax has been corrected. Fixes #7